### PR TITLE
[Feature] Allow specify target type

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Resources:
         HostPattern: '' # optional
         PathPattern: '/*' # optional
         DeregistrationDelayInSeconds: '60' # optional
+        TargetType: 'ip'
       TemplateURL: './node_modules/@cfn-modules/ecs-alb-target/module.yml'
 ```
 
@@ -113,6 +114,13 @@ Resources:
       <td>60</td>
       <td>no</td>
       <td>0-3600</td>
+    </tr>
+    <tr>
+      <td>TargetType</td>
+      <td>The type of target</td>
+      <td>ip</td>
+      <td>no</td>
+      <td>['instance', 'ip', 'lambda']</td>
     </tr>
   </tbody>
 </table>

--- a/module.yml
+++ b/module.yml
@@ -55,6 +55,11 @@ Parameters:
     ConstraintDescription: 'Must be in the range [0-3600]'
     MinValue: 0
     MaxValue: 3600
+  TargetType:
+    Description: 'Optional the type of target.'
+    Type: String
+    Default: 'ip' # compatible with the old version
+    AllowedValues: ['instance', 'ip', 'lambda']
 Conditions:
   HasAlertingModule: !Not [!Equals [!Ref AlertingModule, '']]
   HasPathPattern: !Not [!Equals [!Ref PathPattern, '']]
@@ -84,7 +89,7 @@ Resources:
         HttpCode: '200-399'
       Port: 8080 # overriden when containers are attached
       Protocol: HTTP
-      TargetType: ip
+      TargetType: !Ref TargetType
       TargetGroupAttributes:
       - Key: deregistration_delay.timeout_seconds
         Value: !Ref DeregistrationDelayInSeconds


### PR DESCRIPTION
Allow specify TargetType of TargetGroup.
When ECS service run on network mode `bridge`, you need TargetType `instance`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
