### PR TITLE
allow HealthCheckPort to be specified

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -67,6 +67,10 @@ Parameters:
     Description: 'The HTTP GET request is sent to this path. The response status code must be in the range 200-399 for healthy containers.'
     Type: String
     Default: '/'
+  HealthCheckPort:
+    Description: 'The HTTP GET request is sent to this port.'
+    Type: String
+    Default: '80'
 Conditions:
   HasAlertingModule: !Not [!Equals [!Ref AlertingModule, '']]
   HasCognitoUserPoolModule: !Not [!Equals [!Ref CognitoUserPoolModule, '']]
@@ -121,6 +125,7 @@ Resources:
     Properties:
       HealthCheckIntervalSeconds: 15
       HealthCheckPath: !Ref HealthCheckPath
+      HealthCheckPort: !Ref HealthCheckPort
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 10
       HealthyThresholdCount: 2


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html